### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/blank.yml
+++ b/.github/workflows/blank.yml
@@ -2,6 +2,9 @@
 
 name: CI
 
+permissions:
+  contents: read
+
 # Controls when the workflow will run
 on:
   # Triggers the workflow on push or pull request events but only for the "main" branch


### PR DESCRIPTION
Potential fix for [https://github.com/New-world-wallet/Ettherusd/security/code-scanning/1](https://github.com/New-world-wallet/Ettherusd/security/code-scanning/1)

Add an explicit `permissions` block to the workflow so `GITHUB_TOKEN` is least-privileged by default.  
Best fix here: define permissions at the workflow root (applies to all jobs unless overridden), using:

```yml
permissions:
  contents: read
```

This is sufficient for the current steps (`actions/checkout@v4` + shell echo commands) and does not change existing behavior.  
Edit **`.github/workflows/blank.yml`** by inserting the `permissions` block after the `name` (or before `jobs`) at top level indentation.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
